### PR TITLE
Changed Constructor to accept Configuration instead of string secret key

### DIFF
--- a/src/Service/TokenService.cs
+++ b/src/Service/TokenService.cs
@@ -2,6 +2,7 @@
 {
     #region namespace
     using Interface;
+    using Microsoft.Extensions.Configuration;
     using Model.Token;
     using System;
     using System.Net.Http;
@@ -19,10 +20,11 @@
         #endregion Fields
 
         #region Constructor
-        public TokenService(string apiSecret,
+        public TokenService(IConfiguration configuration,
             HttpClient httpClient)
         {
-            this.apiSecret = apiSecret;
+            apiSecret = configuration["Berbix:API_SECRET_KEY"];
+
             this.httpClient = httpClient;
         }
         #endregion Constructor

--- a/src/Service/TransactionService.cs
+++ b/src/Service/TransactionService.cs
@@ -2,6 +2,7 @@
 {
     #region namespace
     using Interface;
+    using Microsoft.Extensions.Configuration;
     using Model.Transaction;
     using System;
     using System.Net.Http;
@@ -19,10 +20,11 @@
         #endregion Fields
 
         #region Constructor
-        public TransactionService(string apiSecret, 
+        public TransactionService(IConfiguration configuration, 
             HttpClient httpClient)
         {
-            this.apiSecret = apiSecret;
+            apiSecret = configuration["Berbix:API_SECRET_KEY"];
+
             this.httpClient = httpClient;
         }
         #endregion Constructor

--- a/src/berbix-dotnet-sdk.csproj
+++ b/src/berbix-dotnet-sdk.csproj
@@ -5,7 +5,7 @@
     <RootNamespace>Tutkoo.mintyfusion.Berbix.Client</RootNamespace>
     <AssemblyName>Tutkoo.mintyfusion.Berbix.Client</AssemblyName>
     <PackageId>Tutkoo.mintyfusion.Berbix.Client</PackageId>
-    <PackageVersion>1.0.0</PackageVersion>
+    <PackageVersion>1.0.1</PackageVersion>
     <Authors>Tutkoo Inc.</Authors>
     <Owners>Tutkoo Inc.</Owners>
     <Description>C# library provides simple interfaces to interact with the Berbix API.</Description>
@@ -19,7 +19,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="..\LICENSE" Pack="true" PackagePath=""/>
+    <None Include="..\LICENSE" Pack="true" PackagePath="" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.13" />
   </ItemGroup>
 
 </Project>

--- a/test/TokenTests.cs
+++ b/test/TokenTests.cs
@@ -36,7 +36,7 @@
                 BaseAddress = new Uri(Constants.API_URL)
             };
 
-            tokenService = new TokenService(configuration["API_SECRET_KEY"],
+            tokenService = new TokenService(configuration,
                 httpClient);
         }
 

--- a/test/TransactionTests.cs
+++ b/test/TransactionTests.cs
@@ -36,7 +36,7 @@
                 BaseAddress = new Uri(Constants.API_URL)
             };
 
-            transactionService = new TransactionService(configuration["API_SECRET_KEY"],
+            transactionService = new TransactionService(configuration,
                 httpClient);
         }
 


### PR DESCRIPTION
Fixed an issue where passing HttpClient and string value was causing an issue. Decided to inject complete configuration file, so that they can be injected separately.