### PR TITLE
Added underscore in the name instead of color

### DIFF
--- a/src/Constants.cs
+++ b/src/Constants.cs
@@ -12,7 +12,7 @@
 
         public static readonly string HTTP_NAMED_CLIENT = "berbix";
 
-        public static readonly string API_SECRET_KEY_NAME = "Berbix:API_SECRET_KEY";
+        public static readonly string API_SECRET_KEY_NAME = "Berbix_API_SECRET_KEY";
         #endregion Constants
     }
     #endregion Class


### PR DESCRIPTION
This was required otherwise Linux based systems don't work.